### PR TITLE
removed adore odd message 

### DIFF
--- a/msg/Odd.msg
+++ b/msg/Odd.msg
@@ -1,3 +1,0 @@
-bool matching
-float64 time
-string status


### PR DESCRIPTION
Continued work on odd will use the open_odd_ros2_msgs, which are compliant with the ASAM Open Odd standard.